### PR TITLE
[Event Hubs] Remove ability to send single event from Event Hub Client 

### DIFF
--- a/sdk/eventhub/event-hubs/src/aborter.ts
+++ b/sdk/eventhub/event-hubs/src/aborter.ts
@@ -1,0 +1,228 @@
+import { AbortSignalLike, isNode } from "@azure/ms-rest-js";
+
+/**
+ * An aborter instance implements AbortSignal interface, can abort HTTP requests.
+ *
+ * - Call Aborter.none to create a new Aborter instance without timeout.
+ * - Call Aborter.timeout() to create a new Aborter instance with timeout.
+ *
+ * For an existing instance aborter:
+ * - Call aborter.withTimeout() to create and return a child Aborter instance with timeout.
+ * - Call aborter.withValue(key, value) to create and return a child Aborter instance with key/value pair.
+ * - Call aborter.abort() to abort current instance and all children instances.
+ * - Call aborter.getValue(key) to search and get value with corresponding key from current aborter to all parents.
+ */
+
+export class Aborter implements AbortSignalLike {
+  /**
+   * Status of whether aborted or not.
+   *
+   * @readonly
+   * @type {boolean}
+   * @memberof Aborter
+   */
+  public get aborted(): boolean {
+    return this._aborted;
+  }
+
+  /**
+   * onabort event listener.
+   *
+   * @memberof Aborter
+   */
+  public onabort?: (ev?: Event) => any;
+
+  // tslint:disable-next-line:variable-name
+  private _aborted: boolean = false;
+  private timer?: any;
+  private readonly parent?: Aborter;
+  private readonly children: Aborter[] = []; // When child object calls dispose(), remove child from here
+  private readonly abortEventListeners: Array<(this: AbortSignalLike, ev?: any) => any> = [];
+  // Pipeline proxies need to use "abortSignal as Aborter" in order to access non AbortSignalLike methods
+  // immutable primitive types
+  private readonly key?: string;
+  private readonly value?: string | number | boolean | null;
+  // private disposed: boolean = false;
+
+  /**
+   * Private constructor for internal usage, creates an instance of Aborter.
+   *
+   * @param {Aborter} [parent] Optional. Parent aborter.
+   * @param {number} [timeout=0] Optional. Timeout before abort in millisecond, 0 means no timeout.
+   * @param {string} [key] Optional. Immutable key in string.
+   * @param {(string | number | boolean | null)} [value] Optional. Immutable value.
+   * @memberof Aborter
+   */
+  private constructor(parent?: Aborter, timeout: number = 0, key?: string, value?: string | number | boolean | null) {
+    this.parent = parent;
+    this.key = key;
+    this.value = value;
+
+    if (timeout > 0) {
+      this.timer = setTimeout(() => {
+        this.abort.call(this);
+      }, timeout);
+
+      // When called, the active Timeout object will not require the Node.js event loop
+      // to remain active. If there is no other activity keeping the event loop running,
+      // the process may exit before the Timeout object's callback is invoked.
+      if (this.timer && isNode) {
+        this.timer!.unref();
+      }
+    }
+  }
+
+  /**
+   * Create and return a new Aborter instance, which will be appended as a child node of current Aborter.
+   * Current Aborter instance becomes parent node of the new instance. When current or parent Aborter node
+   * triggers timeout event, all children nodes abort event will be triggered too.
+   *
+   * When timeout parameter (in millisecond) is larger than 0, the abort event will be triggered when timeout.
+   * Otherwise, call abort() method to manually abort.
+   *
+   * @param {number} {timeout} Timeout in millisecond.
+   * @returns {Aborter} The new Aborter instance created.
+   * @memberof Aborter
+   */
+  public withTimeout(timeout: number): Aborter {
+    const childCancelContext = new Aborter(this, timeout);
+    this.children.push(childCancelContext);
+    return childCancelContext;
+  }
+
+  /**
+   * Create and return a new Aborter instance, which will be appended as a child node of current Aborter.
+   * Current Aborter instance becomes parent node of the new instance. When current or parent Aborter node
+   * triggers timeout event, all children nodes abort event will be triggered too.
+   *
+   * Immutable key value pair will be set into the new created Aborter instance.
+   * Call getValue() to find out latest value with corresponding key in the chain of
+   * [current node] -> [parent node] and [grand parent node]....
+   *
+   * @param {string} key
+   * @param {(string | number | boolean | null)} [value]
+   * @returns {Aborter}
+   * @memberof Aborter
+   */
+  public withValue(key: string, value?: string | number | boolean | null): Aborter {
+    const childCancelContext = new Aborter(this, 0, key, value);
+    this.children.push(childCancelContext);
+    return childCancelContext;
+  }
+
+  /**
+   * Find out latest value with corresponding key in the chain of
+   * [current node] -> [parent node] -> [grand parent node] -> ... -> [root node].
+   *
+   * If key is not found, undefined will be returned.
+   *
+   * @param {string} key
+   * @returns {(string | number | boolean | null | undefined)}
+   * @memberof Aborter
+   */
+  public getValue(key: string): string | number | boolean | null | undefined {
+    for (let parent: Aborter | undefined = this; parent; parent = parent.parent) {
+      if (parent.key === key) {
+        return parent.value;
+      }
+    }
+    return undefined;
+  }
+
+  /**
+   * Trigger abort event immediately, the onabort and all abort event listeners will be triggered.
+   * Will try to trigger abort event for all children Aborter nodes.
+   *
+   * - If there is a timeout, the timer will be cancelled.
+   * - If aborted is true, nothing will happen.
+   *
+   * @returns
+   * @memberof Aborter
+   */
+  public abort(): void {
+    if (this.aborted) {
+      return;
+    }
+    this.cancelTimer();
+
+    if (this.onabort) {
+      this.onabort.call(this);
+    }
+
+    this.abortEventListeners.forEach(listener => {
+      listener.call(this);
+    });
+
+    this.children.forEach(child => child.cancelByParent());
+
+    this._aborted = true;
+  }
+
+  /**
+   * Added new "abort" event listener, only support "abort" event.
+   *
+   * @param {"abort"} _type Only support "abort" event
+   * @param {(this: AbortSignalLike, ev: any) => any} listener
+   * @memberof Aborter
+   */
+  public addEventListener(
+    // tslint:disable-next-line:variable-name
+    _type: "abort",
+    listener: (this: AbortSignalLike, ev: any) => any
+  ): void {
+    this.abortEventListeners.push(listener);
+  }
+
+  /**
+   * Remove "abort" event listener, only support "abort" event.
+   *
+   * @param {"abort"} _type Only support "abort" event
+   * @param {(this: AbortSignalLike, ev: any) => any} listener
+   * @memberof Aborter
+   */
+  public removeEventListener(
+    // tslint:disable-next-line:variable-name
+    _type: "abort",
+    listener: (this: AbortSignalLike, ev: any) => any
+  ): void {
+    const index = this.abortEventListeners.indexOf(listener);
+    if (index > -1) {
+      this.abortEventListeners.splice(index, 1);
+    }
+  }
+
+  private cancelByParent(): void {
+    this.abort();
+  }
+
+  private cancelTimer(): void {
+    if (this.timer) {
+      clearTimeout(this.timer);
+    }
+  }
+
+  /**
+   * Creates a new Aborter instance without timeout.
+   *
+   * @readonly
+   * @static
+   * @type {Aborter}
+   * @memberof Aborter
+   */
+  public static get none(): Aborter {
+    return new Aborter(undefined, 0);
+  }
+
+  /**
+   * Creates a new Aborter instance with timeout in milliseconds.
+   * Set parameter timeout to 0 will not create a timer.
+   *
+   * @static
+   * @param {number} {timeout} in milliseconds
+   * @returns {Aborter}
+   * @memberof Aborter
+   */
+  public static timeout(timeout: number): Aborter {
+    return new Aborter(undefined, timeout);
+  }
+}

--- a/sdk/eventhub/event-hubs/src/eventHubClient.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubClient.ts
@@ -93,7 +93,6 @@ export interface BatchingOptions extends RequestOptions {
    * It guarantees that messages end up in a specific partition on the event hub.
    */
   batchLabel?: string | null;
-
 }
 
 /**

--- a/sdk/eventhub/event-hubs/src/eventHubClient.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubClient.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import * as log from "./log";
-import { Delivery, WebSocketImpl } from "rhea-promise";
+import { WebSocketImpl } from "rhea-promise";
 import {
   ApplicationTokenCredentials,
   DeviceTokenCredentials,
@@ -83,11 +83,17 @@ export interface RequestOptions {
 /**
  * Options that can be passed to the send operations on the EventHubsClient
  */
-export interface SendOptions extends RequestOptions {
+export interface BatchingOptions extends RequestOptions {
   /**
    * The id of the partition to which the event should be sent
    */
   partitionId?: string;
+  /**
+   * @property {string | null} [batchLabel] If specified EventHub will hash this to a partitionId.
+   * It guarantees that messages end up in a specific partition on the event hub.
+   */
+  batchLabel?: string | null;
+
 }
 
 /**
@@ -296,40 +302,6 @@ export class EventHubClient {
   }
 
   /**
-   * Sends the given message to the EventHub.
-   *
-   * @param data   Message to send.  Will be sent as UTF8-encoded JSON string.
-   * @param partitionId Partition ID to which the event data needs to be sent. This should only be specified
-   * if you intend to send the event to a specific partition. When not specified EventHub will store the messages in a round-robin
-   * fashion amongst the different partitions in the EventHub.
-   *
-   * @returns {Promise<Delivery>} Promise<Delivery>
-   */
-  async send(data: EventData, partitionId?: string | number): Promise<Delivery>;
-  /**
-   * Sends the given message to the EventHub using the options provided.
-   *
-   * @param data  Message to send.  Will be sent as UTF8-encoded JSON string.
-   * @param options Options where you can specifiy the partition to send the message to along with controlling the send
-   * request via retry options, log level and cancellation token.
-   *
-   * @returns {Promise<Delivery>} Promise<Delivery>
-   */
-  async send(data: EventData, options?: SendOptions): Promise<Delivery>;
-  async send(data: EventData, partitionIdOrOptions?: string | number | SendOptions): Promise<Delivery> {
-    let partitionId: string | number | undefined;
-    let sendOptions: SendOptions = {};
-    if (typeof partitionIdOrOptions === "string" || typeof partitionIdOrOptions === "number") {
-      partitionId = partitionIdOrOptions;
-    } else if (partitionIdOrOptions) {
-      partitionId = partitionIdOrOptions.partitionId;
-      sendOptions = partitionIdOrOptions;
-    }
-    const sender = EventHubSender.create(this._context, partitionId);
-    return sender.send(data, sendOptions);
-  }
-
-  /**
    * Send a batch of EventData to the EventHub. The "message_annotations", "application_properties" and "properties"
    * of the first message will be set as that of the envelope (batch message).
    *
@@ -338,9 +310,9 @@ export class EventHubClient {
    * if you intend to send the event to a specific partition. When not specified EventHub will store the messages in a round-robin
    * fashion amongst the different partitions in the EventHub.
    *
-   * @return {Promise<Delivery>} Promise<Delivery>
+   * @return {Promise<void>} Promise<void>
    */
-  async sendBatch(data: EventData[], partitionId?: string | number): Promise<Delivery>;
+  async send(data: EventData[], partitionId?: string | number): Promise<void>;
   /**
    * Send a batch of EventData to the EventHub using the options provided. The "message_annotations", "application_properties" and "properties"
    * of the first message will be set as that of the envelope (batch message).
@@ -349,20 +321,20 @@ export class EventHubClient {
    * @param options Options where you can specifiy the partition to send the message to along with controlling the send
    * request via retry options, log level and cancellation token.
    *
-   * @return {Promise<Delivery>} Promise<Delivery>
+   * @return {Promise<void>} Promise<void>
    */
-  async sendBatch(data: EventData[], options?: SendOptions): Promise<Delivery>;
-  async sendBatch(data: EventData[], partitionIdOrOptions?: string | number | SendOptions): Promise<Delivery> {
+  async send(data: EventData[], options?: BatchingOptions): Promise<void>;
+  async send(data: EventData[], partitionIdOrOptions?: string | number | BatchingOptions): Promise<void> {
     let partitionId: string | number | undefined;
-    let sendOptions: SendOptions = {};
+    let batchingOptions: BatchingOptions = {};
     if (typeof partitionIdOrOptions === "string" || typeof partitionIdOrOptions === "number") {
       partitionId = partitionIdOrOptions;
     } else if (partitionIdOrOptions) {
       partitionId = partitionIdOrOptions.partitionId;
-      sendOptions = partitionIdOrOptions;
+      batchingOptions = partitionIdOrOptions;
     }
     const sender = EventHubSender.create(this._context, partitionId);
-    return sender.sendBatch(data, sendOptions);
+    return sender.send(data, batchingOptions);
   }
 
   /**

--- a/sdk/eventhub/event-hubs/src/eventHubClient.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubClient.ts
@@ -27,6 +27,7 @@ import { EventHubSender } from "./eventHubSender";
 import { StreamingReceiver, ReceiveHandler } from "./streamingReceiver";
 import { BatchingReceiver } from "./batchingReceiver";
 import { IotHubClient } from "./iothub/iothubClient";
+import { Aborter } from "./aborter";
 
 /**
  * LogLevel that defines the level of logging to be used
@@ -73,7 +74,7 @@ export interface RequestOptions {
   /**
    * The cancellation token used to cancel the current request
    */
-  cancellationToken?: any;
+  cancellationToken?: Aborter;
   /**
    * Log level to use for the current operation. This overrides the value set when creating the EventHubsClient
    */

--- a/sdk/eventhub/event-hubs/src/eventHubClient.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubClient.ts
@@ -303,20 +303,17 @@ export class EventHubClient {
   }
 
   /**
-   * Send a batch of EventData to the EventHub. The "message_annotations", "application_properties" and "properties"
-   * of the first message will be set as that of the envelope (batch message).
+   * Send a batch of EventData to the EventHub.
    *
-   * @param {Array<EventData>} datas  An array of EventData objects to be sent in a Batch message.
-   * @param {string|number} [partitionId] Partition ID to which the event data needs to be sent. This should only be specified
-   * if you intend to send the event to a specific partition. When not specified EventHub will store the messages in a round-robin
-   * fashion amongst the different partitions in the EventHub.
+   * @param data  An array of EventData objects to be sent in a Batch message.
+   * @param partitionId Partition ID to which the event data needs to be sent. When not specified EventHub will store
+   * the messages in a round-robin fashion amongst the different partitions in the EventHub.
    *
-   * @return {Promise<void>} Promise<void>
+   * @return Promise<void>
    */
   async send(data: EventData[], partitionId?: string | number): Promise<void>;
   /**
-   * Send a batch of EventData to the EventHub using the options provided. The "message_annotations", "application_properties" and "properties"
-   * of the first message will be set as that of the envelope (batch message).
+   * Send a batch of EventData to the EventHub using the options provided.
    *
    * @param data  An array of EventData objects to be sent in a Batch message.
    * @param options Options where you can specifiy the partition to send the message to along with controlling the send

--- a/sdk/eventhub/event-hubs/src/eventHubClient.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubClient.ts
@@ -81,7 +81,7 @@ export interface RequestOptions {
 }
 
 /**
- * Options that can be passed to the send operations on the EventHubsClient
+ * Options that can be passed when sending a batch of events using the EventHubsClient
  */
 export interface BatchingOptions extends RequestOptions {
   /**
@@ -89,8 +89,9 @@ export interface BatchingOptions extends RequestOptions {
    */
   partitionId?: string;
   /**
-   * @property {string | null} [batchLabel] If specified EventHub will hash this to a partitionId.
-   * It guarantees that messages end up in a specific partition on the event hub.
+   * @property {string | null} [batchLabel] If specified EventHub will hash this string to a partitionId.
+   * It guarantees that messages end up in the same partition on the event hub.
+   * This will be ignored if `paritionId` is used when sending events.
    */
   batchLabel?: string | null;
 }

--- a/sdk/eventhub/event-hubs/src/index.ts
+++ b/sdk/eventhub/event-hubs/src/index.ts
@@ -5,7 +5,7 @@ export { EventData, EventHubDeliveryAnnotations, EventHubMessageAnnotations } fr
 export { Delivery, AmqpError, Message, MessageHeader, MessageProperties, Dictionary, WebSocketImpl } from "rhea-promise";
 export { ReceiverRuntimeInfo, OnMessage, OnError } from "./eventHubReceiver";
 export { ReceiveHandler } from "./streamingReceiver";
-export { EventHubClient, ReceiveOptions, ClientOptions, SendOptions, RequestOptions, LogLevel } from "./eventHubClient";
+export { EventHubClient, ReceiveOptions, ClientOptions, BatchingOptions, RequestOptions, LogLevel } from "./eventHubClient";
 export { EventPosition } from "./eventPosition";
 export { EventHubPartitionRuntimeInformation, EventHubRuntimeInformation } from "./managementClient";
 import { Constants } from "@azure/amqp-common";

--- a/sdk/eventhub/event-hubs/test/client.spec.ts
+++ b/sdk/eventhub/event-hubs/test/client.spec.ts
@@ -159,7 +159,7 @@ describe("EventHubClient on ", function(): void {
     it("should throw MessagingEntityNotFoundError while creating a sender", async function(): Promise<void> {
       try {
         client = EventHubClient.createFromConnectionString(service.connectionString!, "bad" + Math.random());
-        await client.send({ body: "Hello World" }, "0");
+        await client.send([{ body: "Hello World" }], "0");
       } catch (err) {
         debug(err);
         should.equal(err.name, "MessagingEntityNotFoundError");

--- a/sdk/eventhub/event-hubs/test/misc.spec.ts
+++ b/sdk/eventhub/event-hubs/test/misc.spec.ts
@@ -49,7 +49,7 @@ describe("Misc tests", function(): void {
     });
     let data = await breceiver.receive(5, 10);
     data.length.should.equal(0, "Unexpected to receive message before client sends it");
-    await client.send(obj, partitionId);
+    await client.send([obj], partitionId);
     debug("Successfully sent the large message.");
     data = await breceiver.receive(5, 30);
     debug("Closing the receiver..");
@@ -82,7 +82,7 @@ describe("Misc tests", function(): void {
     breceiver = BatchingReceiver.create((client as any)._context, partitionId, {
       eventPosition: EventPosition.fromOffset(offset)
     });
-    await client.send(obj, partitionId);
+    await client.send([obj], partitionId);
     debug("Successfully sent the large message.");
     const data = await breceiver.receive(5, 30);
     await breceiver.close();
@@ -113,7 +113,7 @@ describe("Misc tests", function(): void {
     breceiver = BatchingReceiver.create((client as any)._context, partitionId, {
       eventPosition: EventPosition.fromOffset(offset)
     });
-    await client.send(obj, partitionId);
+    await client.send([obj], partitionId);
     debug("Successfully sent the large message.");
     const data = await breceiver.receive(5, 30);
     await breceiver.close();
@@ -135,7 +135,7 @@ describe("Misc tests", function(): void {
     breceiver = BatchingReceiver.create((client as any)._context, partitionId, {
       eventPosition: EventPosition.fromOffset(offset)
     });
-    await client.send(obj, partitionId);
+    await client.send([obj], partitionId);
     debug("Successfully sent the large message.");
     const data = await breceiver.receive(5, 30);
     await breceiver.close();
@@ -165,7 +165,7 @@ describe("Misc tests", function(): void {
       }
       d[0].partitionKey = "pk1234656";
 
-      await client.sendBatch(d, partitionId);
+      await client.send(d, partitionId);
       debug("Successfully sent 5 messages batched together.");
       data = await breceiver.receive(5, 30);
       await breceiver.close();
@@ -216,7 +216,7 @@ describe("Misc tests", function(): void {
       }
       d[0].partitionKey = "pk1234656";
 
-      await client.sendBatch(d, partitionId);
+      await client.send(d, partitionId);
       debug("Successfully sent 5 messages batched together.");
       data = await breceiver.receive(5, 30);
       await breceiver.close();
@@ -249,7 +249,7 @@ describe("Misc tests", function(): void {
     }
     for (let i = 0; i < msgToSendCount; i++) {
       const partitionKey = getRandomInt(10);
-      await client.send({ body: "Hello EventHub " + i, partitionKey: partitionKey.toString() });
+      await client.send([{ body: "Hello EventHub " + i, partitionKey: partitionKey.toString() }]);
     }
     debug("Starting to receive all messages from each partition.");
     const partitionMap: any = {};

--- a/sdk/eventhub/event-hubs/test/receiver.spec.ts
+++ b/sdk/eventhub/event-hubs/test/receiver.spec.ts
@@ -79,7 +79,7 @@ describe("EventHub Receiver", function(): void {
         const ed: EventData = {
           body: "Hello awesome world " + i
         };
-        await client.send(ed, partitionId);
+        await client.send([ed], partitionId);
         debug("sent message - " + i);
       }
       debug("Creating new receiver with offset EndOfStream");
@@ -96,7 +96,7 @@ describe("EventHub Receiver", function(): void {
           stamp: uid
         }
       };
-      await client.send(ed, partitionId);
+      await client.send([ed], partitionId);
       debug(">>>>>>> Sent the new message after creating the receiver. We should only receive this message.");
       const data2 = await breceiver.receive(10, 20);
       debug("received messages: ", data2);
@@ -125,7 +125,7 @@ describe("EventHub Receiver", function(): void {
           stamp: uid
         }
       };
-      await client.send(ed, "0");
+      await client.send([ed], "0");
       debug("Sent the new message after creating the receiver. We should only receive this message.");
       const data = await breceiver.receive(10, 20);
       debug("received messages: ", data);
@@ -147,7 +147,7 @@ describe("EventHub Receiver", function(): void {
           stamp: uid
         }
       };
-      await client.send(ed, partitionId);
+      await client.send([ed], partitionId);
       debug(`Sent message 1 with stamp: ${uid}.`);
       const pInfo = await client.getPartitionInformation(partitionId);
       const uid2 = uuid();
@@ -157,7 +157,7 @@ describe("EventHub Receiver", function(): void {
           stamp: uid2
         }
       };
-      await client.send(ed2, partitionId);
+      await client.send([ed2], partitionId);
       debug(`Sent message 2 with stamp: ${uid} after getting the enqueued offset.`);
       debug(`Creating new receiver with last enqueued offset: "${pInfo.lastEnqueuedOffset}".`);
       breceiver = BatchingReceiver.create((client as any)._context, partitionId, {
@@ -192,7 +192,7 @@ describe("EventHub Receiver", function(): void {
           stamp: uid
         }
       };
-      await client.send(ed, partitionId);
+      await client.send([ed], partitionId);
       debug("Sent the new message after creating the receiver. We should only receive this message.");
       const data = await breceiver.receive(10, 20);
       debug("received messages: ", data);
@@ -214,7 +214,7 @@ describe("EventHub Receiver", function(): void {
           stamp: uid
         }
       };
-      await client.send(ed, partitionId);
+      await client.send([ed], partitionId);
       debug(
         "Sent the new message after getting the partition runtime information. We should only receive this message."
       );
@@ -242,7 +242,7 @@ describe("EventHub Receiver", function(): void {
           stamp: uid
         }
       };
-      await client.send(ed, partitionId);
+      await client.send([ed], partitionId);
       debug(`Sent message 1 with stamp: ${uid}.`);
       const pInfo = await client.getPartitionInformation(partitionId);
       const uid2 = uuid();
@@ -252,7 +252,7 @@ describe("EventHub Receiver", function(): void {
           stamp: uid2
         }
       };
-      await client.send(ed2, partitionId);
+      await client.send([ed2], partitionId);
       debug(`Sent message 2 with stamp: ${uid}.`);
       debug(`Creating new receiver with last sequence number: "${pInfo.lastSequenceNumber}".`);
       breceiver = BatchingReceiver.create((client as any)._context, partitionId, {
@@ -580,7 +580,7 @@ describe("EventHub Receiver", function(): void {
       body: "Hello World"
     };
     const partitionIds = await client.getPartitionIds();
-    await client.send(data, partitionIds[0]);
+    await client.send([data], partitionIds[0]);
     const errorMessage = "Will we see this error message?";
 
     const onMessageHandler = (brokeredMessage: EventData) => {


### PR DESCRIPTION
The Service team wants to encourage the use of sending in a batch rather than sending individual events for better performance. Updating the send APIs to incorporate this feedback for Track 2

**This PR updates the following:**
*  Remove send() in `EventHubClient`.
*  Rename sendBatch() to send().
*  Rename SendOptions to BatchingOptions.
*  Add "batchLabel"(partitionKey) to "BatchingOptions".